### PR TITLE
Fix issue with generating same number when calling the function

### DIFF
--- a/poisson.cpp
+++ b/poisson.cpp
@@ -3,10 +3,11 @@
 #include <iostream>
 #include "poisson.h"
 
+std::random_device rd;
+std::mt19937 gen(rd());
+
 luint poisson(luint lambda)
 {
-    std::random_device rd;
-    std::mt19937 gen(rd());
     std::poisson_distribution<luint> d(lambda);
     return d(gen);
 }


### PR DESCRIPTION
The poisson function had the random device and generator within the function, which caused the generator to initialize with the same property on calling the function and thus returning the same number over and over again. The issue is fixed and the random device and generator are moved outside the function.